### PR TITLE
Draft: Improve API endpoint for demorunners

### DIFF
--- a/ci_tests/system.py
+++ b/ci_tests/system.py
@@ -15,7 +15,7 @@ class IntegrationTests(unittest.TestCase):
     Integration Tests
     """
     # General
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
 
     # These variables are initialized in the __main__
     test_ddl_file = None
@@ -178,7 +178,7 @@ class IntegrationTests(unittest.TestCase):
     #####################
 
     def post(self, module, service, params=None, data=None, files=None, servicejson=None):
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def check_status(self, response, error_msg):

--- a/cp2/ControlPanel/ControlPanel/settings.py
+++ b/cp2/ControlPanel/ControlPanel/settings.py
@@ -29,37 +29,26 @@ SECRET_KEY = 'ng&u0bv6bm6cs+w+c#=*b0-#g-e_*t(my7(q@&1@^b5m@-)&^!'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-HOST_NAME = socket.getfqdn()
+HOST_NAME = os.environ.get('IPOL_HOST', socket.getfqdn())
+IPOL_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
 ALLOWED_HOSTS = []
 
 dev_machines = ['127.0.0.1', 'localhost', 'integration.ipol.im']
 production_servers = ['ipolcore.ipol.im']
 
+ALLOWED_HOSTS = [HOST_NAME]
+
+CORS_ALLOWED_ORIGINS = [
+    IPOL_URL,
+]
+CSRF_TRUSTED_ORIGINS = [
+    IPOL_URL,
+]
+
 if HOST_NAME in dev_machines:
     DEBUG = True
-    ALLOWED_HOSTS = [socket.getfqdn(), '127.0.0.1']
-
-    CORS_ALLOWED_ORIGINS = [
-        "http://localhost",
-        "http://127.0.0.1",
-        "https://integration.ipol.im",
-    ]
-    CSRF_TRUSTED_ORIGINS = [
-        "http://localhost",
-        "http://127.0.0.1",
-        "https://integration.ipol.im",
-    ]
-
 elif HOST_NAME in production_servers:
     DEBUG = False
-    ALLOWED_HOSTS = [socket.getfqdn()]
-
-    CORS_ALLOWED_ORIGINS = [
-        "https://ipolcore.ipol.im",
-    ]
-    CSRF_TRUSTED_ORIGINS = [
-        "https://ipolcore.ipol.im",
-    ]
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/

--- a/cp2/ControlPanel/ControlPanel/utils.py
+++ b/cp2/ControlPanel/ControlPanel/utils.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import socket
 import json
@@ -8,9 +9,8 @@ from django.contrib.auth.models import User
 #function in order to know wich machine/server it's used for POST and GET methods (/api/....) 
 
 def api_post(resource, params=None, files=None, json=None):
-    server = socket.gethostbyname(socket.getfqdn())
-    print(f"http://{server}{resource}")
-    return requests.post(f"http://{server}{resource}", params=params, data=json, files=files)
+    host = os.environ.get('IPOL_URL', socket.gethostbyname(socket.getfqdn()))
+    return requests.post(f"{host}{resource}", params=params, data=json, files=files)
 
 
 def user_can_edit_demo(user, demo_id):

--- a/cp2/gunicorn_start_cp2
+++ b/cp2/gunicorn_start_cp2
@@ -10,6 +10,9 @@ fi
 
 source $virtualenv
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 NAME="cp2"                                  # Name of the application
 USER=ipol                                        # the user to run as
 PORT=8002

--- a/ipol_demo/modules/archive/start.sh
+++ b/ipol_demo/modules/archive/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py archive.conf &" >/dev/null &

--- a/ipol_demo/modules/archive/test.py
+++ b/ipol_demo/modules/archive/test.py
@@ -17,7 +17,7 @@ class ArchiveTests(unittest.TestCase):
     """
     ArchiveTests
     """
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'archive'
 
     # Blob info
@@ -300,7 +300,7 @@ class ArchiveTests(unittest.TestCase):
         """
         post
         """
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def add_experiment(self, demo_id, blobs_path, parameters, execution):

--- a/ipol_demo/modules/blobs/start.sh
+++ b/ipol_demo/modules/blobs/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py blobs.conf &" >/dev/null &

--- a/ipol_demo/modules/blobs/test.py
+++ b/ipol_demo/modules/blobs/test.py
@@ -16,7 +16,7 @@ class BlobsTests(unittest.TestCase):
     """
     BlobsTests
     """
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'blobs'
 
     # Blob info
@@ -648,7 +648,7 @@ class BlobsTests(unittest.TestCase):
         """
             post
         """
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def add_blob_to_demo(self, blob=None, demo_id=None, blob_set=None, pos_set=None, title=None,

--- a/ipol_demo/modules/conversion/start.sh
+++ b/ipol_demo/modules/conversion/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py conversion.conf &" >/dev/null &

--- a/ipol_demo/modules/conversion/test.py
+++ b/ipol_demo/modules/conversion/test.py
@@ -28,7 +28,7 @@ class ConversionImageTests(unittest.TestCase):
     """
     Dispatcher tests.
     """
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'conversion'
     blob_path = None
 
@@ -297,7 +297,7 @@ class ConversionImageTests(unittest.TestCase):
         """
         Do a post
         """
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def convert(self, input_dir, input_desc, crop_info):
@@ -315,7 +315,7 @@ class ConversionVideoTests(unittest.TestCase):
     """
     Dispatcher tests.
     """
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'conversion'
     blob_path = None
 
@@ -604,7 +604,7 @@ class ConversionVideoTests(unittest.TestCase):
         """
         Do a post
         """
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def convert(self, work_dir, input_desc, crop_info):

--- a/ipol_demo/modules/core/archive.py
+++ b/ipol_demo/modules/core/archive.py
@@ -31,7 +31,7 @@ def create_thumbnail(src_file):
     except Exception:
         return False
 
-def send_to_archive(demo_id, work_dir, request, ddl_archive, res_data, host_name):
+def send_to_archive(demo_id, work_dir, request, ddl_archive, res_data, base_url):
     """
     Prepare an execution folder for archiving an experiment (thumbnails).
     Collect information and parameters.
@@ -105,7 +105,7 @@ def send_to_archive(demo_id, work_dir, request, ddl_archive, res_data, host_name
     else:
         execution_json = None
 
-    url = 'http://{}/api/archive/add_experiment'.format(host_name)
+    url = '{}/api/archive/add_experiment'.format(base_url)
     data = {
         "demo_id": demo_id,
         "blobs": json.dumps(blobs),

--- a/ipol_demo/modules/core/core.py
+++ b/ipol_demo/modules/core/core.py
@@ -1349,8 +1349,9 @@ attached the failed experiment data.". \
             # Archive the experiment, if the 'archive' section exists in the DDL and it is not a private execution
             # Also check if it is an original uploaded data from the user (origin != 'blobset') or is enabled archive_always
             if not private_mode and 'archive' in ddl and (origin != 'blobset' or ddl['archive'].get('archive_always')):
+                base_url = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
                 try:
-                    response = send_to_archive(demo_id, work_dir, kwargs, ddl['archive'], demorunner_response, socket.getfqdn())
+                    response = send_to_archive(demo_id, work_dir, kwargs, ddl['archive'], demorunner_response, base_url)
                     if not response['status'] == 'OK':
                         id_experiment = response.get('id_experiment', None)
                         message = "KO from archive module when archiving an experiment: demo={}, key={}, id={}."
@@ -1519,11 +1520,6 @@ attached the failed experiment data.". \
         return dic
 
     @staticmethod
-    def post(api_url, data=None, host=None):
-        """
-        Make a POST request via the IPOL API
-        """
-        if host is None:
-            host = socket.getfqdn()
-        url = 'http://{0}/{1}'.format(host, api_url)
-        return requests.post(url, data=data)
+    def post(api_url, data=None):
+        base_url = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
+        return requests.post(f'{base_url}/{api_url}', data=data)

--- a/ipol_demo/modules/core/start.sh
+++ b/ipol_demo/modules/core/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py core.conf &" >/dev/null &

--- a/ipol_demo/modules/demoinfo/start.sh
+++ b/ipol_demo/modules/demoinfo/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py demoinfo.conf &" >/dev/null &

--- a/ipol_demo/modules/demoinfo/test.py
+++ b/ipol_demo/modules/demoinfo/test.py
@@ -17,8 +17,7 @@ class DemoinfoTests(unittest.TestCase):
     """
     Demoinfo unit tests
     """
-
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'demoinfo'
 
     # Demo
@@ -958,7 +957,7 @@ class DemoinfoTests(unittest.TestCase):
         """
         post
         """
-        url = 'http://{}/api/{}/{}'.format(self.HOST, module, service)
+        url = '{}/api/{}/{}'.format(self.BASE_URL, module, service)
         return requests.post(url, params=params, data=data, files=files, json=servicejson)
 
     def read_ddl(self):

--- a/ipol_demo/modules/demorunner-docker/start.sh
+++ b/ipol_demo/modules/demorunner-docker/start.sh
@@ -15,7 +15,7 @@ if ! command -v cargo &> /dev/null; then
     exit 1
 fi
 
-cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev f5790b0803adcd48cb004333dab21ef7b3e0fbcd --root . --target-dir target --debug --force --locked
+cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev 65909c086c0a2762c63ce5fade48dfca85db0520 --root . --target-dir target --debug --force --locked
 
 export ROCKET_PROFILE=ipol-$(hostname)
 bin/ipol-demorunner >logs 2>&1 &

--- a/ipol_demo/modules/demorunner/start.sh
+++ b/ipol_demo/modules/demorunner/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py demorunner.conf &" >/dev/null &

--- a/ipol_demo/modules/dispatcher/dispatcher.py
+++ b/ipol_demo/modules/dispatcher/dispatcher.py
@@ -157,8 +157,8 @@ class Dispatcher():
         demorunners = []
         for dr in self.demorunners:
             try:
-                response = requests.get(
-                    'http://{}/api/demorunner/get_workload'.format(dr.server), timeout=3)
+                url = f'{dr.server}/api/demorunner/{dr.name}/get_workload'
+                response = requests.get(url, timeout=3)
                 if not response:
                     demorunners.append({'status': 'KO', 'name': dr.name})
                     continue
@@ -291,7 +291,8 @@ class Dispatcher():
         dr_server = chosen_dr.server
 
         # Check if the DR is up.
-        dr_response = requests.get('http://{}/api/demorunner/ping'.format(dr_server), timeout=3)
+        url = f'{dr_server}/api/demorunner/{dr_name}/ping'
+        dr_response = requests.get(url, timeout=3)
         if not dr_response:
             self.error_log("get_suitable_demorunner",
                            "Module {} unresponsive".format(dr_name))
@@ -311,8 +312,7 @@ class Dispatcher():
         dr_workload = {}
         for dr_info in self.demorunners:
             try:
-                dr_server = dr_info.server
-                url = 'http://{}/api/demorunner/get_workload'.format(dr_server)
+                url = f'{dr_info.server}/api/demorunner/{dr_info.name}/get_workload'
                 resp = requests.get(url, timeout=3)
                 if not resp:
                     error_message = "No response from DR='{}'".format(dr_info.name)

--- a/ipol_demo/modules/dispatcher/start.sh
+++ b/ipol_demo/modules/dispatcher/start.sh
@@ -8,4 +8,7 @@ if [ ! -d "venv" ]; then
   ./venv/bin/pip install -r requirements.txt
 fi
 
+export IPOL_HOST=$(hostname -f)
+export IPOL_URL=http://$(hostname -f)
+
 nohup bash -c "source ./venv/bin/activate && python main.py dispatcher.conf &" >/dev/null &

--- a/ipol_demo/modules/dispatcher/test.py
+++ b/ipol_demo/modules/dispatcher/test.py
@@ -4,6 +4,7 @@
 Dispatcher test
 """
 # Unit tests for the Blobs module
+import os
 import socket
 import sys
 import unittest
@@ -39,7 +40,7 @@ class DispatcherTests(unittest.TestCase):
     """
     Dispatcher tests
     """
-    HOST = socket.getfqdn()
+    BASE_URL = os.environ.get('IPOL_URL', 'http://' + socket.getfqdn())
     module = 'dispatcher'
 
     demorunners = []
@@ -53,7 +54,7 @@ class DispatcherTests(unittest.TestCase):
         """
         status = None
         try:
-            ping = 'http://{}/api/dispatcher/ping'.format(self.HOST)
+            ping = '{}/api/dispatcher/ping'.format(self.BASE_URL)
             response = requests.get(ping).json()
             status = response.get('status')
         finally:
@@ -64,8 +65,7 @@ class DispatcherTests(unittest.TestCase):
         Test get suitable demorunner
         """
         try:
-            suitable_dr = 'http://{}/api/dispatcher/get_suitable_demorunner'.format(
-                self.HOST)
+            suitable_dr = '{}/api/dispatcher/get_suitable_demorunner'.format(self.BASE_URL)
             response = requests.get(suitable_dr).json()
             status = response.get('status')
         finally:
@@ -78,8 +78,7 @@ class DispatcherTests(unittest.TestCase):
         """
         status = 'OK'
         try:
-            suitable_dr = 'http://{}/api/dispatcher/get_suitable_demorunner'.format(
-                self.HOST)
+            suitable_dr = '{}/api/dispatcher/get_suitable_demorunner'.format(self.BASE_URL)
             for demorunner in self.demorunners:
                 capabilities = self.demorunners[demorunner]['capabilities'].split(',')
                 capabilities_as_requirements = [cap.rstrip('!') for cap in capabilities]
@@ -96,7 +95,7 @@ class DispatcherTests(unittest.TestCase):
         """
         status = 'KO'
         try:
-            dr_stats = 'http://{}/api/dispatcher/get_demorunners_stats'.format(self.HOST)
+            dr_stats = '{}/api/dispatcher/get_demorunners_stats'.format(self.BASE_URL)
             response = requests.get(dr_stats).json()
             for dr in response.get('demorunners'):
                 if dr['status'] == 'OK' and 'workload' in dr:

--- a/ipol_webapp/apps/controlpanel/views/ipolwebservices/ipolservices.py
+++ b/ipol_webapp/apps/controlpanel/views/ipolwebservices/ipolservices.py
@@ -217,7 +217,6 @@ def demoinfo_delete_demo(demo_id):
     http_request("/api/blobs/delete_demo", METHOD='POST', params={'demo_id': demo_id})
     http_request("/api/demoinfo/delete_demoextras", METHOD='POST', params={'demo_id': demo_id})
     http_request("/api/archive/delete_demo", METHOD='POST', params={'demo_id': demo_id})
-    http_request("/api/demorunner/delete_compilation", METHOD='GET', params={'demo_id': demo_id})
     return demoinfo_resp
 
 

--- a/sysadmin/configs/nginx/default-integration
+++ b/sysadmin/configs/nginx/default-integration
@@ -207,8 +207,8 @@ server {
 	}
 
 	# DEMORUNNER
-	location /api/demorunner/ {
-		rewrite ^/api/demorunner/(.*) /$1 break;
+	location /api/demorunner/my-dr/ {
+		rewrite ^/api/demorunner/my-dr/(.*) /$1 break;
 		resolver 127.0.0.1;
 		proxy_pass   http://$host:9004;
 	}

--- a/sysadmin/configs/nginx/default-local
+++ b/sysadmin/configs/nginx/default-local
@@ -140,8 +140,8 @@ server {
 	}
 
 	# DEMORUNNER
-	location /api/demorunner/ {
-		rewrite ^/api/demorunner/(.*) /$1 break;
+	location /api/demorunner/my-dr {
+		rewrite ^/api/demorunner/my-dr/(.*) /$1 break;
 		# If the distribution is Debian you need the resolver		
 		# resolver 127.0.0.1;
 		proxy_pass   http://$host:9004;

--- a/sysadmin/configs/nginx/default-prod
+++ b/sysadmin/configs/nginx/default-prod
@@ -182,8 +182,8 @@ server {
     }
 
     # DEMORUNNER
-    location /api/demorunner/ {
-        rewrite ^/api/demorunner/(.*) /$1 break;
+    location /api/demorunner/my-dr/ {
+        rewrite ^/api/demorunner/my-dr/(.*) /$1 break;
         resolver 127.0.0.1;
         proxy_pass  http://$host:9004;
     }


### PR DESCRIPTION
1. api change: `/api/demorunner/<call>` -> `/api/demorunner/<dr-name>/<call>`
2. internal services now talk to the main nginx using the environment variable IPOL_HOST / IPOL_URL, which is more flexible than `socket.getfqdn()` (including the possibility to use https instead of the hard-coded http)
3. the `server` field of the demorunners should be set to IPOL_URL in all cases, this field can be removed in the future. Nginx will route to the right demorunner

This was not tested in the docker test environment, but I don't expect major changes.

DR tests are probably broken and should use the main nginx instead.