### PR TITLE
[core/dr] remove run shared folders

### DIFF
--- a/ipol_demo/modules/demorunner-docker/Rocket.toml
+++ b/ipol_demo/modules/demorunner-docker/Rocket.toml
@@ -1,6 +1,5 @@
 [default]
 compilation_root = "./compilation/"
-execution_root = "/home/ipol/ipolDevel/shared_folder/run/"
 docker_image_prefix = "ipol-demo-"
 docker_exec_prefix = "ipol-exec-"
 exec_workdir_in_docker = "/workdir/exec"
@@ -9,6 +8,7 @@ gpus = []
 env_vars = {"IPOL_URL"="https://ipolcore.ipol.im"}
 ssh_key_path = "id_ed25519"
 max_timeout = 600
+limits = {"file"="500MB", "data-form"="500MB"}
 
 [ipol-ipolcore]
 port = 3000

--- a/ipol_demo/modules/demorunner-docker/start.sh
+++ b/ipol_demo/modules/demorunner-docker/start.sh
@@ -15,7 +15,7 @@ if ! command -v cargo &> /dev/null; then
     exit 1
 fi
 
-cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev a2788cedd2d12c6620fb5194746a613b7cbe5211 --root . --target-dir target --debug --force --locked
+cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev 4f865887b52c534582e9d702d4d662634141d771 --root . --target-dir target --debug --force --locked
 
 export ROCKET_PROFILE=ipol-$(hostname)
 bin/ipol-demorunner >logs 2>&1 &

--- a/ipol_demo/modules/demorunner/demorunner.conf
+++ b/ipol_demo/modules/demorunner/demorunner.conf
@@ -24,7 +24,6 @@ response.headers.content-type = 'application/json;charset=utf-8'
 config_common_dir    = os.path.expanduser('~') + '/ipolDevel/ipol_demo/modules/config_common'
 
 # Directories in the shared folder
-share.running.dir    = os.path.expanduser('~') + '/ipolDevel/shared_folder/run'
 share.demoExtras.dir = os.path.expanduser('~') + '/ipolDevel/shared_folder/demoExtras'
 
 compilation_lock_filename = 'ipol_construct.lock'

--- a/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev a2788cedd2d12c6620fb5194746a613b7cbe5211 --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev 4f865887b52c534582e9d702d4d662634141d771 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule-gpu

--- a/sysadmin/systemd/limule/ipol-demorunner-docker.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev a2788cedd2d12c6620fb5194746a613b7cbe5211 --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/kidanger/ipol-demorunner.git --rev 4f865887b52c534582e9d702d4d662634141d771 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule


### PR DESCRIPTION
Input files are passed during the /exec_and_wait HTTP request to the DR, and the DR now returns a zip containing everything, including a `exec_info.json` file that corresponds to the old DR payload.