### PR TITLE
Security/python multipart update version

### DIFF
--- a/ipol_demo/modules/core/pyproject.toml
+++ b/ipol_demo/modules/core/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic==2.12.4",
     "pydantic-settings>=2.12.0",
     "python-magic==0.4.24",
-    "python-multipart==0.0.19",
+    "python-multipart==0.0.22",
     "requests==2.32.5",
     "result==0.8.0",
     "tifffile==2025.1.10",

--- a/ipol_demo/modules/core/uv.lock
+++ b/ipol_demo/modules/core/uv.lock
@@ -136,7 +136,7 @@ requires-dist = [
     { name = "pydantic", specifier = "==2.12.4" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "python-magic", specifier = "==0.4.24" },
-    { name = "python-multipart", specifier = "==0.0.19" },
+    { name = "python-multipart", specifier = "==0.0.22" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "result", specifier = "==0.8.0" },
     { name = "tifffile", specifier = "==2025.1.10" },
@@ -485,11 +485,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.19"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c1/19/93bfb43a3c41b1dd0fa1fa66a08286f6467d36d30297a7aaab8c0b176a26/python_multipart-0.0.19.tar.gz", hash = "sha256:905502ef39050557b7a6af411f454bc19526529ca46ae6831508438890ce12cc", size = 36886, upload-time = "2024-12-01T07:00:44.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/f4/ddd0fcdc454cf3870153ae16a818256523d31c3c8136e216bc6836ed4cd1/python_multipart-0.0.19-py3-none-any.whl", hash = "sha256:f8d5b0b9c618575bf9df01c684ded1d94a338839bdd8223838afacfb4bb2082d", size = 24448, upload-time = "2024-12-01T07:00:40.031Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]

--- a/ipol_demo/modules/demorunner/pyproject.toml
+++ b/ipol_demo/modules/demorunner/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "psutil==5.9.5",
     "pydantic==1.10.9",
     "python-magic==0.4.27",
-    "python-multipart==0.0.22",
+    "python-multipart==0.0.19",
     "requests==2.32.5",
     "uvicorn==0.22.0",
     "virtualenv==20.26.6",

--- a/ipol_demo/modules/demorunner/pyproject.toml
+++ b/ipol_demo/modules/demorunner/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "psutil==5.9.5",
     "pydantic==1.10.9",
     "python-magic==0.4.27",
-    "python-multipart==0.0.19",
+    "python-multipart==0.0.22",
     "requests==2.32.5",
     "uvicorn==0.22.0",
     "virtualenv==20.26.6",


### PR DESCRIPTION
[Dependabot alert on python-multipart "high risk"](https://github.com/advisories/GHSA-wp53-j4wj-2cfg/dependabot?query=user:ipol-journal
)

Vulnerability fixed on Core module. Needs uv sync or restarting module.
Python demorunner can't update this package due to python being locked on 3.9.* which is incompatible with the fixed version. 

We should consider adding a task to update demorunner to a newer python version in the near future.
