### PR TITLE
Runtime/error archive link

### DIFF
--- a/ipol_demo/modules/core/core/core.py
+++ b/ipol_demo/modules/core/core/core.py
@@ -853,12 +853,31 @@ class Core:
         if not emails:
             return
 
-        # Attach experiment in zip file and send the email
-        text = "This is the IPOL Core machine.\n\n\
-    The execution with key={} of demo #{} on {} has failed.\nProblem: {}.\nPlease find \
-    attached the failed experiment data.".format(
-            key, demo_id, demorunner, message
-        )
+        # Create persistent error archive directory
+        error_dir = os.path.join(self.shared_folder_abs, "error_archives")
+        os.makedirs(error_dir, exist_ok=True)
+
+        zip_filename = os.path.join(error_dir, "{}.zip".format(key))
+
+        # Zip the contents of the failed experiment
+        zipf = zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED)
+        run_path = os.path.join(self.shared_folder_abs, "run", str(demo_id), key)
+        self.zipdir(run_path, zipf)
+        zipf.close()
+
+        logger.info(f"Persistent ZIP created at: {zip_filename}")
+
+        # Generate download link
+        download_url = f"{self.base_url}/api/core/error-archive/{key}.zip"
+
+        text = f"""This is the IPOL Core machine.
+        
+        The execution with key={key} of demo #{demo_id} on {demorunner} has failed.
+        Problem: {message}.
+        
+        The failed experiment archive can be downloaded here:
+        {download_url}
+        """
 
         if self.server_environment == "production":
             machine = "Core"
@@ -867,12 +886,6 @@ class Core:
 
         subject = "[IPOL {}] Demo #{} execution failure".format(machine, demo_id)
 
-        # Zip the contents of the tmp/ directory of the failed experiment
-        zip_filename = "/tmp/{}.zip".format(key)
-        zipf = zipfile.ZipFile(zip_filename, "w", zipfile.ZIP_DEFLATED)
-        self.zipdir("{}/run/{}/{}".format(self.shared_folder_abs, demo_id, key), zipf)
-        zipf.close()
-
         # Send email only if the demo is not in the ignored id list
         if demo_id not in id_list:
             self.send_email(
@@ -880,12 +893,7 @@ class Core:
                 text,
                 emails,
                 config_emails["sender"],
-                zip_filename=zip_filename,
             )
-        try:
-            os.remove(zip_filename)
-        except OSError:
-            pass
 
     def send_demorunner_unresponsive_email(self, unresponsive_demorunners):
         """

--- a/ipol_demo/modules/core/core/router.py
+++ b/ipol_demo/modules/core/core/router.py
@@ -24,8 +24,7 @@ from core.errors import (
 )
 from demoinfo import demoinfo
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import HTMLResponse
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from guards import validate_ip
 from ipolutils.evaluator.evaluator import IPOLEvaluateError
 from logger import logger

--- a/ipol_demo/modules/core/core/router.py
+++ b/ipol_demo/modules/core/core/router.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import traceback
 
 from archive import archive
@@ -24,6 +25,7 @@ from core.errors import (
 from demoinfo import demoinfo
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse
+from fastapi.responses import FileResponse
 from guards import validate_ip
 from ipolutils.evaluator.evaluator import IPOLEvaluateError
 from logger import logger
@@ -57,6 +59,31 @@ def ping():
     Ping: answer with a PONG.
     """
     return {"status": "OK", "ping": "pong"}
+
+
+@coreRouter.get("/error-archive/{filename}")
+def download_error_archive(filename: str):
+    """
+    Serve runtime error archive (ZIP file).
+    """
+    # Validate filename format (32 uppercase hex chars + .zip)
+    if not re.match(r"^[A-F0-9]{32}\.zip$", filename):
+        raise HTTPException(status_code=400, detail="Invalid filename")
+
+    error_dir = os.path.join(core.shared_folder_abs, "error_archives")
+    file_path = os.path.join(error_dir, filename)
+
+    # Security: prevent path traversal
+    abs_error_dir = os.path.abspath(error_dir)
+    abs_file_path = os.path.abspath(file_path)
+
+    if not abs_file_path.startswith(abs_error_dir):
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    if not os.path.exists(abs_file_path):
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(abs_file_path, media_type="application/zip", filename=filename)
 
 
 @coreRouter.on_event("shutdown")

--- a/sysadmin/cleanup.sh
+++ b/sysadmin/cleanup.sh
@@ -8,3 +8,10 @@ find ${BASE} -maxdepth 2 -ctime +30 -type d -exec rm -rf {} \;
 
 # Remove demo directories without any executions
 find ${BASE} -maxdepth 1 -type d -empty -exec rm -rf {} \;
+
+# Remove error archive ZIP files older than 30 days
+ERROR_ARCHIVES="/home/ipol/ipolDevel/shared_folder/error_archives/"
+
+if [ -d "$ERROR_ARCHIVES" ]; then
+    find ${ERROR_ARCHIVES} -type f -name "*.zip" -mtime +30 -exec rm -f {} \;
+fi


### PR DESCRIPTION
- Replaces email attachment of runtime failure ZIP files with a downloadable link
- Stores failed experiment archives in a persistent location
- Adds a secure API endpoint to download error archives
- Extends existing cleanup script to automatically delete old archives after 30 days