### PR TITLE
fixed demo id and title width on demo page

### DIFF
--- a/ipol_demo/modules/core/templates/index.html
+++ b/ipol_demo/modules/core/templates/index.html
@@ -21,7 +21,7 @@
             line-height: 1.6;
             color: var(--text-color);
             background-color: var(--bg-color);
-            max-width: 900px;
+            max-width: 1200px;
             margin: 0 auto;
             padding: 2rem;
         }
@@ -115,9 +115,13 @@
         .demo-title {
             color: var(--link-color);
             font-weight: 500;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
         }
 
         .demo-id {
+            flex: none;
             font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
             color: #6c757d;
             font-size: 0.9em;


### PR DESCRIPTION
Fixes demo id and demo title width for long IDs and demo titles

<img width="1255" height="85" alt="image" src="https://github.com/user-attachments/assets/5b548c29-9bcc-4846-a546-4242dd58b028" />
